### PR TITLE
Fix issue of skipping characters when pasting in text.

### DIFF
--- a/input.c
+++ b/input.c
@@ -102,6 +102,8 @@ static int _keyboard_input_timeout = 100000;		/* 0.1 seconds; it's in usec */
 static int ibuffer_space PARAMS((void));
 static int rl_get_char PARAMS((int *));
 static int rl_gather_tyi PARAMS((void));
+int rl_stuff_char PARAMS((int key));
+
 
 /* Windows isatty returns true for every character device, including the null
    device, so we need to perform additional checks. */
@@ -217,9 +219,8 @@ rl_gather_tyi (void)
   tty = fileno (rl_instream);
   if (isatty (tty) && (waiting_char = _read_kbd(0, 0, 0)) != -1 && ibuffer_space ())
     {
-      int i;
-      i = (*rl_getc_function) (rl_instream);
-      rl_stuff_char (i);
+      rl_stuff_char (waiting_char);
+      waiting_char = -1;
       return 1;
     }
   return 0;
@@ -349,8 +350,11 @@ _rl_input_available (void)
 #if defined (__LIBCN__)
   int tty;
   tty = fileno (rl_instream);
-  if (isatty (tty) && (waiting_char = _read_kbd(0, 0, 0)) != -1)
+  if (isatty (tty) && (waiting_char = _read_kbd(0, 0, 0)) != -1) {
+    rl_stuff_char (waiting_char);
+    waiting_char = -1;
     return 1;
+  }
 #else // __LIBCN__
 
 #if defined(HAVE_SELECT)


### PR DESCRIPTION
I believe this is happening when pasting since keys are entering the buffer
faster than were' pulling them out, so there's a new one available when
calling _read_kbd(0,1,0) and that one is returned instead of repeating the
last discarded one that was saved in waiting_char.

This fixes bash where you can paste into the OS/2 terminal, also tested with
rlbasic.exe.